### PR TITLE
chore: split out a adminGate middleware

### DIFF
--- a/server/api/gatekeeper.js
+++ b/server/api/gatekeeper.js
@@ -1,0 +1,14 @@
+const adminGate = (req, res, next) => {
+  try {
+    if (req.user && req.user.isAdmin) {
+      next()
+    } else {
+      const newErr = new Error('Unauthorized API Request')
+      newErr.status = 403
+      throw newErr
+    }
+  } catch (e) {
+    next(e)
+  }
+}
+module.exports = {adminGate}

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -1,4 +1,5 @@
 const router = require('express').Router()
+const {adminGate} = require('./gatekeeper')
 const {Order, User, Product, OrderItem} = require('../db/models')
 module.exports = router
 
@@ -158,19 +159,7 @@ router.post('/checkout', async (req, res, next) => {
 })
 
 // ALL ORDERS VIEW FOR ADMIN
-router.use('*', (req, res, next) => {
-  try {
-    if (req.user && req.user.isAdmin) {
-      next()
-    } else {
-      const newErr = new Error('Unauthorized API Request')
-      newErr.status = 403
-      throw newErr
-    }
-  } catch (e) {
-    next(e)
-  }
-})
+router.use('*', adminGate)
 
 // GET /api/orders
 router.get('/', async (req, res, next) => {

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -1,5 +1,6 @@
 const router = require('express').Router()
 const {Product} = require('../db/models')
+const {adminGate} = require('./gatekeeper')
 module.exports = router
 
 /* All Products Routes */
@@ -10,8 +11,6 @@ router.get('/', async (req, res, next) => {
     const products = await Product.findAll({
       attributes: ['id', 'name', 'imageUrl', 'price', 'inventory'],
     })
-
-    //TODO: Confirm currency is sent to front-end as a properly localized string.
 
     res.json(products)
   } catch (err) {
@@ -36,19 +35,7 @@ router.get('/:productId', async (req, res, next) => {
 })
 
 /* Admin-Only Product Modification Routes */
-router.use('*', (req, res, next) => {
-  try {
-    if (req.user && req.user.isAdmin) {
-      next()
-    } else {
-      const newErr = new Error('Unauthorized API Request')
-      newErr.status = 403
-      throw newErr
-    }
-  } catch (e) {
-    next(e)
-  }
-})
+router.use('*', adminGate)
 
 //POST /api/products/
 router.post('/', async (req, res, next) => {

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -1,15 +1,10 @@
 const router = require('express').Router()
 const {User} = require('../db/models')
+const {adminGate} = require('./gatekeeper')
 module.exports = router
 
-router.get('/', async (req, res, next) => {
+router.get('/', adminGate, async (req, res, next) => {
   try {
-    if (!req.user || (req.user && !req.user.getDataValue('isAdmin'))) {
-      const newErr = new Error('Unauthorized API Request')
-      newErr.status = 403
-      throw newErr
-    }
-
     const users = await User.findAll({
       // explicitly select only the id and email fields - even though
       // users' passwords are encrypted, it won't help if we just


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] written relevant docs (or none needed)
- [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

Makes admin-only routes more DRY by creating an adminGate middleware.

It can be called as one middleware within a route, or used to protect all downstream routes with router.use('*', adminGate)
